### PR TITLE
Disable input autocomplete when adding attendees

### DIFF
--- a/src/client/ui/event_tooltip/editable/attendee_sub_tooltip.jsx
+++ b/src/client/ui/event_tooltip/editable/attendee_sub_tooltip.jsx
@@ -149,6 +149,7 @@ export default class AttendeeSubTooltip extends React.Component {
                             <input
                               id="event-new-attendee-input"
                               type="email"
+                              autocomplete="off"
                               placeholder="Email"
                               onChange={this.debounced_autocomplete}
                               autoFocus


### PR DESCRIPTION
This fixes the issue with Chrome autocomplete drop-down covering part of attendee search list:

![screenshot from 2017-11-26 02-21-05](https://user-images.githubusercontent.com/8214/33236638-930bc0b6-d251-11e7-9bce-d370e6d943db.png)
